### PR TITLE
Fix Discord bot showing localhost URLs in golden answer links

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -23,6 +23,8 @@ export const ConfigSchema = z.object({
   // ML Service configuration
   ML_SERVICE_URL: z.string().url().default('http://localhost:8080'),
   ML_SERVICE_API_KEY: z.string().min(1, 'ML_SERVICE_API_KEY is required'),
+  // Frontend configuration
+  FRONTEND_URL: z.string().url().default('http://localhost:3000'),
   // Sync configuration
   SYNC_MAX_CHANNEL_WORKERS: z.coerce.number().int().positive().default(10),
   SYNC_CHANNEL_BATCH_SIZE: z.coerce.number().int().positive().default(5),

--- a/backend/src/services/ResponseGeneratorService.ts
+++ b/backend/src/services/ResponseGeneratorService.ts
@@ -4,6 +4,7 @@ import { SearchApiRequest } from 'shared-types';
 import logger from '../utils/logger.js';
 import { ApiError } from '../middleware/errorHandler.js';
 import type { KnowledgeBaseChunkRepository } from '../repositories/knowledgeBase/types.js';
+import { config } from '../config/env.js';
 
 export interface BotResponse {
   content: string;
@@ -456,7 +457,7 @@ ${sources.map(source => {
           source = {
             type: 'golden_answer',
             title: `Golden Answer: ${result.metadata?.question || 'FAQ'}`,
-            url: result.metadata?.id ? `http://localhost:3000/faq#${result.metadata.id}` : undefined,
+            url: result.metadata?.id ? `${config.FRONTEND_URL}/faq#${result.metadata.id}` : undefined,
             excerpt: result.content?.slice(0, 100),
             count: 1,
           };

--- a/charts/verta/values.yaml
+++ b/charts/verta/values.yaml
@@ -50,6 +50,7 @@ backend:
     REDIS_HOST: "{{ .Release.Name }}-redis"
     REDIS_PORT: "6379"
     ML_SERVICE_URL: "http://{{ .Release.Name }}-ml:8000"
+    FRONTEND_URL: "https://{{ .Values.global.domain }}"
   
   # Health check configuration
   livenessProbe:


### PR DESCRIPTION
## Summary
Discord /ask responses were showing localhost:3000 URLs for golden answer links instead of the actual production domain.

## Changes
- Added `FRONTEND_URL` environment variable to backend configuration with default value for development
- Configured `FRONTEND_URL` in Helm chart to use `https://{{ .Values.global.domain }}`
- Updated ResponseGeneratorService to use `config.FRONTEND_URL` instead of hardcoded localhost URL

## Testing
- [x] Code changes reviewed
- [ ] Tested locally with custom FRONTEND_URL
- [ ] Verified Helm template renders correctly

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Impact
Golden answer links in Discord bot responses will now correctly point to the production domain (e.g., `https://verta.example.com/faq#id`) instead of `http://localhost:3000/faq#id`.